### PR TITLE
♻️ refactor: 근무일정 캘린더 중복문제 해결

### DIFF
--- a/ON-CARE-FE/src/views/careworker/workschedule/WorkschedulePage.vue
+++ b/ON-CARE-FE/src/views/careworker/workschedule/WorkschedulePage.vue
@@ -554,6 +554,42 @@ const getServiceTypeId = (serviceTypeName) => {
   return mapping[serviceTypeName] || null;
 };
 
+// 일정 시간대 겹침 검사 함수
+const hasTimeConflict = (date, startTime, endTime, excludeScheduleId = null) => {
+  // 같은 날짜의 일정들 필터링
+  const sameDateSchedules = schedules.value.filter(schedule => {
+    // 수정 모드일 때 현재 수정중인 일정은 제외
+    if (excludeScheduleId && (schedule.scheduleId || schedule.id) === excludeScheduleId) {
+      return false;
+    }
+    return schedule.date === date;
+  });
+
+  // 시간대 겹침 확인
+  for (const schedule of sameDateSchedules) {
+    const existingStart = schedule.startTime;
+    const existingEnd = schedule.endTime;
+    const newStart = startTime;
+    const newEnd = endTime;
+
+    // 시간대가 겹치는 경우:
+    // 1. 새 일정의 시작이 기존 일정 중간에 있거나
+    // 2. 새 일정의 종료가 기존 일정 중간에 있거나
+    // 3. 새 일정이 기존 일정을 완전히 포함하거나
+    // 4. 기존 일정이 새 일정을 완전히 포함하는 경우
+    if (
+      (newStart >= existingStart && newStart < existingEnd) || // 시작시간이 기존 일정 중간
+      (newEnd > existingStart && newEnd <= existingEnd) ||     // 종료시간이 기존 일정 중간
+      (newStart <= existingStart && newEnd >= existingEnd) ||  // 새 일정이 기존 일정 포함
+      (newStart >= existingStart && newEnd <= existingEnd)     // 기존 일정이 새 일정 포함
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const saveSchedule = async () => {
   try {
     if (!newSchedule.value.date || !newSchedule.value.startTime || !newSchedule.value.endTime) {
@@ -563,6 +599,13 @@ const saveSchedule = async () => {
 
     if (newSchedule.value.startTime >= newSchedule.value.endTime) {
       alert('종료 시간은 시작 시간보다 늦어야 합니다.');
+      return;
+    }
+
+    // 일정 시간대 겹침 검사 (수정 모드일 때는 현재 일정 제외)
+    const excludeId = isEditMode.value ? editingScheduleId.value : null;
+    if (hasTimeConflict(newSchedule.value.date, newSchedule.value.startTime, newSchedule.value.endTime, excludeId)) {
+      alert('이미 등록된 일정이 있습니다.');
       return;
     }
 


### PR DESCRIPTION
## 📝 PR 내용
- 근무일정 캘린더에 같은 시간에 일정 등록을 못하도록 수정하였습니다.

## 📮 관련 이슈 번호
- 

## ✨ 변경 유형
- [ ] 신규 기능 추가 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 기타 (Typo, Config, etc.)

## 📢 특이사항

## ✅ 체크리스트
- [ ] **PR 대상 브랜치가 main이 아닌지 확인했나요?** (Feature 브랜치 등)
- [ ] 관련 이슈를 연결했나요?
- [ ] 로컬 환경에서 테스트를 통해 동작을 확인했나요?
